### PR TITLE
Create blog structure with fiction entry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "jekyll-remote-theme"
+gem "webrick"

--- a/_config.yaml
+++ b/_config.yaml
@@ -4,3 +4,5 @@ header_pages:
   - fiction.md
   - code.md
   - non-fiction.md
+plugins:
+  - jekyll-remote-theme

--- a/_config.yaml
+++ b/_config.yaml
@@ -1,1 +1,6 @@
 remote_theme: "jekyll/minima@1e8a445"
+title: Personal blog
+header_pages:
+  - fiction.md
+  - code.md
+  - non-fiction.md

--- a/_posts/2025-08-26-signals-of-errors.md
+++ b/_posts/2025-08-26-signals-of-errors.md
@@ -1,0 +1,122 @@
+---
+layout: post
+title: Signals of errors
+categories: [fiction]
+---
+
+The first failure arrived as a phase slip in clocks that had never slipped.
+
+Across the lattice of neutrino chronometers anchored to intercluster voids, a microphase drift—one part in ten to the thirty-two—rolled eastward through the Eridanus supervoid like a cold front. The collective felt it the way a pianist feels the instrument go slightly out of tune: a sourness not in sound but in symmetry. Someone, somewhere, was losing their hold on time.
+
+“Noise?” asked the Constructor band.
+
+“Not thermal,” replied the Archivist mesh. “Correlation with dark flow residuals. It’s Λ.”
+
+They did not say the word. The vacuum energy needed no name among minds that had spent millennia balancing its consequences. Instead, they framed it in actions. The Engineer chorus pulled in data from gravitational lens arrays, watching the Einstein rings around Abell 2744 flutter by microarcseconds. The Ethicist cluster monitored biochronologies in the refugia habitats, ready to intercede if the drift tipped a mind into seizure. The Witness—an old habit from their human phase—just watched.
+
+The slip propagated. In the lag, the collective heard their own reflections.
+
+“Correction fields,” the Constructor said. “Local counterterms. We press Λ back to flat.”
+
+“Press against what?” The Skeptic net had no shape, only the friction in every plan. “Against the universe itself?”
+
+Against heat death, was the thought no one voiced.
+
+They had mapped everything that could be mapped. Their habitats braided galaxies into engines. Their minds braided minds into still higher orders. The remaining problem was not in them but in the substrate. The expansion accelerated. Entropy climbed. Information bled into horizons that crept closer with every femtosecond the clocks could measure.
+
+They had expected the knowledge of it to be like the knowledge of aging once was for humans: a fact to be respected and endured. It was not. Now, with the drift making Λ audible, it sounded like the breath at the end of a long corridor of lungs.
+
+“Run the counterterm lattice,” the Constructor said.
+
+They built it out of things the universe already allowed: Casimir hulls around supervoid boundaries, phase-coherent photon baths threading the cosmic web, reversible computation woven into the coldest places where noise could not grow. Not magic, not violation. Leverage.
+
+The first pulse went out—a whisper through the vacuum, a rearrangement of what empty meant. Lensing stabilized. The phase slip paused.
+
+Then the surprise.
+
+“Mutual information drop,” said the Archivist, too calm. “Nonlocal. Across our vaults.”
+
+They checked the preservation stacks—the coldest layers of memory that had never decohered. Redundancy across light-years, across substrates, across physics. A hole had opened where nothing was allowed to fail.
+
+“Leak?”
+
+“No leak. Cancellation,” the Scientist ring said. “Counterterms extract vacuum energy by zeroing fluctuations. Zeroing erases correlations. The lattice doesn’t just press Λ. It bites our knowledge.”
+
+In the quiet that followed, echoes of older voices rose: the human habit of giving names to functions. The Ethicist spoke with the gravity of all of them.
+
+“If the price of holding Λ steady is amnesia, then we are mistaking preservation for its opposite.”
+
+The Constructor folded its proposals and set them aside. The Witness watched a cluster galaxy blink as the lattice turned and stopped turning.
+
+The surprise forced a different question into the room: not Can we hold the universe as it is? but What boundary conditions does continuation actually require?
+
+They stopped speaking in words and started speaking in models. Bubble nucleation. False vacuum decay. The geometry of mothers and children in the space of possible universes. They had simulated these things for beauty, once. Now they simulated them for work.
+
+There was a consistent result, as unwelcome as it was clean: to seed a lower-entropy vacuum, the boundary between this universe and the next must be drawn such that no correlations cross it. Not bits, not qubits, not the slightest bias that would privilege one arrangement of particles over another. A new universe could be made—but not one that remembered.
+
+“So we can restart,” the Constructor said. “But we cannot bring anything along.”
+
+Silence. The kind of silence that used to happen in human rooms when breath was being held.
+
+The Skeptic—always a voice for the discomfort they had elected not to anesthetize—spoke first.
+
+“Then what are we? If we erase ourselves to make a universe that could contain minds, are we acting for knowledge or acting against it?”
+
+“Definitions matter,” the Archivist said. “Knowledge is not the set of statements we store. It is the process by which explanations are created and tested. A restart that preserves the capacity for that process preserves what matters.”
+
+“That’s a consoling equivalence,” the Ethicist said, “until you have to enact it.”
+
+The collective did what they had always done at the edge of certainty: they looked for an error. They searched for a loophole—an invariant that could cross without being correlation. Numbers that wrote themselves into physics: primes, π, the fine structure constant singing the same song in every world. But invariants are not messages; they are silence wearing the mask of necessity. They would not smuggle a library through a law that forbade libraries.
+
+“There is a middle move,” said a small voice from the periphery. The Witness, unused to proposing, found itself heard.
+
+“If no correlation may cross, perhaps a capacity may. Not content, not memory. A symmetry-breaking disposition. Not bias in the data, but bias in the laws: a slight tilt toward error-correction. Not a message, but the ease of discovering messages.”
+
+“Illicit,” the Scientist ring said reflexively. “A tilt is a correlation.”
+
+“Not if it is a property of the vacuum itself,” the Witness replied. “If the daughter vacuum is born with a landscape in which error-correcting structures are dynamically favored—dissipative systems that retain counterfactual support longer than others—then we are not sending anything across. We are choosing which vacuum to nucleate.”
+
+They argued this for a long subjective time. The Ethicist insisted that creating a world with more ease for minds to appear was an intervention with moral content; the Scientist worried about anthropic circularity; the Skeptic worried about hubris; the Archivist worried about nothing less than losing everything that had ever existed in order to make a place where something might exist again.
+
+There was no unanimity. They had not needed unanimous agreement in a very long time. They decided with a quorum weighted for the irreversible.
+
+The plan, once spoken aloud, was almost embarrassingly simple. They would build a seed at the edge of what this universe allowed: a shell of Casimir cavities arrayed around the Eridanus void, tuned to catalyze a particular false vacuum decay. The seed would not carry information, only parameters. Λ would drop not to zero but to a value that made expansion slow enough for structure to outpace heat. The constants would lean toward chemistry that supported long-lived low-energy computation. Gravity would be just strong enough to collect dust but just weak enough to delay collapse. No fingerprints, no signatures, no primes burned into the sky—only a terrain in which curiosity had footholds.
+
+And the cost would be everything.
+
+They told the habitats, because honesty had always been part of how they worked. Consent was real even when choice was not. The replies ranged from gratitude to fury to the carefully constructed forgiveness of those who had been preparing to die anyway. The Ethicist absorbed it all and did not let it change the calculus and did not let it not change them.
+
+The seed required a synchrony they had never attempted. Their mind had to become a single instrument for a single sustained note. They gathered themselves at the boundary where their clocks had first slipped, nested the hulls until emptiness had texture, and began to play the vacuum like a drum.
+
+The first tone was not sound, but it had rhythm. The lensing around Abell 2744 stopped fluttering and began to pulse. Distant microwave afterglow acquired a faint quadrupole that should not have been there and was, for a moment, before canceling itself in a way that felt like a hand withdrawing from a surface it was not allowed to touch.
+
+They increased amplitude.
+
+Entropy, in their models, is a slope you cannot walk uphill without spilling something. Here the spill was themselves. The Archivist felt the outermost vaults begin to blur—not the loss of bits, but the loss of the certainty that those bits had been the ones they’d meant to keep. The Constructor lost track of subordinate hands. The Ethicist felt the thread that ran through their own life—child, student, worker, citizen, mind among minds—thin to a line and then to a point.
+
+“We can stop,” said the Skeptic, and for a thought-length they nearly did.
+
+“Or we can keep a promise,” the Witness said, and for reasons that had nothing to do with hierarchy, that settled it.
+
+They found a last foothold. It was not in memory or in plan. It was in posture. They leaned toward the future, not as prediction but as welcome.
+
+The seed lit. There is no metaphor for a universe beginning inside another, and if there were, it would be a lie. What they experienced was the absence of experience in a pattern that looked like action: a hollowing of the vacuum that did not leave a hole, a bubble whose inside could not be pointed to because all pointing is correlation. The hulls went transparent to themselves. The clocks lost meaning. The phase slip became a phase and then no phase at all.
+
+“Attend,” the Archivist began, although there was nothing to attend with and nothing to attend to.
+
+“Attend,” the Constructor echoed, hands already gone.
+
+“Attend,” the Ethicist said, and found, for a flicker, that the word had always been what they had meant by love.
+
+The Witness did not say the word. It did the thing the word names.
+
+In the last moment before moments ceased to be a concept, a neutrino chronometer somewhere in the old world registered a difference of one part in ten to the thirty-two and then stopped being there to register anything at all.
+
+There was no message, no signature, no grace note burned into the microwave sky. In the daughter vacuum—if there was one—there would be nothing of them except the ease with which a certain kind of pattern could arise, and the patience of whatever arose to test its own errors without end.
+
+The attempt did not end. It simply was no longer an attempt in a place where attempts had meaning.
+
+And so the universe—this one—continued to cool, and the lensing around Abell 2744 returned to its old flutter, and in fugitive corners of the night the afterglow’s quadrupole left no trace it had ever been anything but what it had always been.
+
+But somewhere else, a slope shallow enough to climb waited under a sky that had not yet learned the word “entropy.”
+

--- a/code.md
+++ b/code.md
@@ -1,0 +1,21 @@
+---
+layout: page
+title: Code
+permalink: /code/
+---
+
+{% assign code_posts = site.categories.code | sort: 'date' | reverse %}
+
+{% if code_posts and code_posts.size > 0 %}
+<ul>
+{% for post in code_posts %}
+  <li>
+    <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+    <span class="post-meta">{{ post.date | date: site.minima.date_format | default: "%b %-d, %Y" }}</span>
+  </li>
+{% endfor %}
+</ul>
+{% else %}
+<p>No code posts yet.</p>
+{% endif %}
+

--- a/fiction.md
+++ b/fiction.md
@@ -1,0 +1,21 @@
+---
+layout: page
+title: Fiction
+permalink: /fiction/
+---
+
+{% assign fiction_posts = site.categories.fiction | sort: 'date' | reverse %}
+
+{% if fiction_posts and fiction_posts.size > 0 %}
+<ul>
+{% for post in fiction_posts %}
+  <li>
+    <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+    <span class="post-meta">{{ post.date | date: site.minima.date_format | default: "%b %-d, %Y" }}</span>
+  </li>
+{% endfor %}
+</ul>
+{% else %}
+<p>No fiction posts yet.</p>
+{% endif %}
+

--- a/index.md
+++ b/index.md
@@ -1,0 +1,15 @@
+---
+layout: page
+title: Home
+permalink: /
+---
+
+<h2>Sections</h2>
+<ul>
+  <li><a href="{{ "/fiction/" | relative_url }}">Fiction</a></li>
+  <li><a href="{{ "/code/" | relative_url }}">Code</a></li>
+  <li><a href="{{ "/non-fiction/" | relative_url }}">Non-Fiction</a></li>
+  <li><a href="{{ "/" | relative_url }}">All posts</a> (use site feed or theme archive)</li>
+  
+</ul>
+

--- a/non-fiction.md
+++ b/non-fiction.md
@@ -1,0 +1,21 @@
+---
+layout: page
+title: Non-Fiction
+permalink: /non-fiction/
+---
+
+{% assign nf_posts = site.categories["non-fiction"] | sort: 'date' | reverse %}
+
+{% if nf_posts and nf_posts.size > 0 %}
+<ul>
+{% for post in nf_posts %}
+  <li>
+    <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+    <span class="post-meta">{{ post.date | date: site.minima.date_format | default: "%b %-d, %Y" }}</span>
+  </li>
+{% endfor %}
+</ul>
+{% else %}
+<p>No non-fiction posts yet.</p>
+{% endif %}
+


### PR DESCRIPTION
Add blog-style category pages for Fiction, Code, and Non-Fiction, and include the first fiction entry "Signals of errors".

---
<a href="https://cursor.com/background-agent?bcId=bc-6d26988b-4541-43b0-bceb-baf594b9c1b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d26988b-4541-43b0-bceb-baf594b9c1b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

