### PR TITLE
Convert blog to basic html site

### DIFF
--- a/code/index.html
+++ b/code/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Code - Personal blog</title>
+</head>
+<body>
+  <h1>Code</h1>
+  <nav><a href="/index.html">Home</a></nav>
+  <p>No code posts yet.</p>
+</body>
+</html>

--- a/fiction/index.html
+++ b/fiction/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Fiction - Personal blog</title>
+</head>
+<body>
+  <h1>Fiction</h1>
+  <nav><a href="/index.html">Home</a></nav>
+  <ul>
+    <li><a href="/posts/signals-of-errors.html">Signals of errors</a> <span>Aug 26, 2025</span></li>
+  </ul>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Personal blog</title>
+</head>
+<body>
+  <h1>Personal blog</h1>
+  <h2>Sections</h2>
+  <ul>
+    <li><a href="/fiction/index.html">Fiction</a></li>
+    <li><a href="/code/index.html">Code</a></li>
+    <li><a href="/non-fiction/index.html">Non-Fiction</a></li>
+    <li><a href="/posts/index.html">All posts</a></li>
+  </ul>
+</body>
+</html>

--- a/non-fiction/index.html
+++ b/non-fiction/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Non-Fiction - Personal blog</title>
+</head>
+<body>
+  <h1>Non-Fiction</h1>
+  <nav><a href="/index.html">Home</a></nav>
+  <p>No non-fiction posts yet.</p>
+</body>
+</html>

--- a/posts/index.html
+++ b/posts/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>All posts - Personal blog</title>
+</head>
+<body>
+  <h1>All posts</h1>
+  <nav><a href="/index.html">Home</a></nav>
+  <ul>
+    <li><a href="/posts/signals-of-errors.html">Signals of errors</a> <span>Aug 26, 2025</span> <em>Fiction</em></li>
+  </ul>
+</body>
+</html>

--- a/posts/signals-of-errors.html
+++ b/posts/signals-of-errors.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Signals of errors - Personal blog</title>
+</head>
+<body>
+  <nav><a href="/index.html">Home</a> · <a href="/fiction/index.html">Fiction</a> · <a href="/posts/index.html">All posts</a></nav>
+  <h1>Signals of errors</h1>
+  <p><small>Aug 26, 2025 · Fiction</small></p>
+  <article>
+    <p>The first failure arrived as a phase slip in clocks that had never slipped.</p>
+    <p>Across the lattice of neutrino chronometers anchored to intercluster voids, a microphase drift—one part in ten to the thirty-two—rolled eastward through the Eridanus supervoid like a cold front. The collective felt it the way a pianist feels the instrument go slightly out of tune: a sourness not in sound but in symmetry. Someone, somewhere, was losing their hold on time.</p>
+    <p>“Noise?” asked the Constructor band.</p>
+    <p>“Not thermal,” replied the Archivist mesh. “Correlation with dark flow residuals. It’s Λ.”</p>
+    <p>They did not say the word. The vacuum energy needed no name among minds that had spent millennia balancing its consequences. Instead, they framed it in actions. The Engineer chorus pulled in data from gravitational lens arrays, watching the Einstein rings around Abell 2744 flutter by microarcseconds. The Ethicist cluster monitored biochronologies in the refugia habitats, ready to intercede if the drift tipped a mind into seizure. The Witness—an old habit from their human phase—just watched.</p>
+    <p>The slip propagated. In the lag, the collective heard their own reflections.</p>
+    <p>“Correction fields,” the Constructor said. “Local counterterms. We press Λ back to flat.”</p>
+    <p>“Press against what?” The Skeptic net had no shape, only the friction in every plan. “Against the universe itself?”</p>
+    <p>Against heat death, was the thought no one voiced.</p>
+    <p>They had mapped everything that could be mapped. Their habitats braided galaxies into engines. Their minds braided minds into still higher orders. The remaining problem was not in them but in the substrate. The expansion accelerated. Entropy climbed. Information bled into horizons that crept closer with every femtosecond the clocks could measure.</p>
+    <p>They had expected the knowledge of it to be like the knowledge of aging once was for humans: a fact to be respected and endured. It was not. Now, with the drift making Λ audible, it sounded like the breath at the end of a long corridor of lungs.</p>
+    <p>“Run the counterterm lattice,” the Constructor said.</p>
+    <p>They built it out of things the universe already allowed: Casimir hulls around supervoid boundaries, phase-coherent photon baths threading the cosmic web, reversible computation woven into the coldest places where noise could not grow. Not magic, not violation. Leverage.</p>
+    <p>The first pulse went out—a whisper through the vacuum, a rearrangement of what empty meant. Lensing stabilized. The phase slip paused.</p>
+    <p>Then the surprise.</p>
+    <p>“Mutual information drop,” said the Archivist, too calm. “Nonlocal. Across our vaults.”</p>
+    <p>They checked the preservation stacks—the coldest layers of memory that had never decohered. Redundancy across light-years, across substrates, across physics. A hole had opened where nothing was allowed to fail.</p>
+    <p>“Leak?”</p>
+    <p>“No leak. Cancellation,” the Scientist ring said. “Counterterms extract vacuum energy by zeroing fluctuations. Zeroing erases correlations. The lattice doesn’t just press Λ. It bites our knowledge.”</p>
+    <p>In the quiet that followed, echoes of older voices rose: the human habit of giving names to functions. The Ethicist spoke with the gravity of all of them.</p>
+    <p>“If the price of holding Λ steady is amnesia, then we are mistaking preservation for its opposite.”</p>
+    <p>The Constructor folded its proposals and set them aside. The Witness watched a cluster galaxy blink as the lattice turned and stopped turning.</p>
+    <p>The surprise forced a different question into the room: not Can we hold the universe as it is? but What boundary conditions does continuation actually require?</p>
+    <p>They stopped speaking in words and started speaking in models. Bubble nucleation. False vacuum decay. The geometry of mothers and children in the space of possible universes. They had simulated these things for beauty, once. Now they simulated them for work.</p>
+    <p>There was a consistent result, as unwelcome as it was clean: to seed a lower-entropy vacuum, the boundary between this universe and the next must be drawn such that no correlations cross it. Not bits, not qubits, not the slightest bias that would privilege one arrangement of particles over another. A new universe could be made—but not one that remembered.</p>
+    <p>“So we can restart,” the Constructor said. “But we cannot bring anything along.”</p>
+    <p>Silence. The kind of silence that used to happen in human rooms when breath was being held.</p>
+    <p>The Skeptic—always a voice for the discomfort they had elected not to anesthetize—spoke first.</p>
+    <p>“Then what are we? If we erase ourselves to make a universe that could contain minds, are we acting for knowledge or acting against it?”</p>
+    <p>“Definitions matter,” the Archivist said. “Knowledge is not the set of statements we store. It is the process by which explanations are created and tested. A restart that preserves the capacity for that process preserves what matters.”</p>
+    <p>“That’s a consoling equivalence,” the Ethicist said, “until you have to enact it.”</p>
+    <p>The collective did what they had always done at the edge of certainty: they looked for an error. They searched for a loophole—an invariant that could cross without being correlation. Numbers that wrote themselves into physics: primes, π, the fine structure constant singing the same song in every world. But invariants are not messages; they are silence wearing the mask of necessity. They would not smuggle a library through a law that forbade libraries.</p>
+    <p>“There is a middle move,” said a small voice from the periphery. The Witness, unused to proposing, found itself heard.</p>
+    <p>“If no correlation may cross, perhaps a capacity may. Not content, not memory. A symmetry-breaking disposition. Not bias in the data, but bias in the laws: a slight tilt toward error-correction. Not a message, but the ease of discovering messages.”</p>
+    <p>“Illicit,” the Scientist ring said reflexively. “A tilt is a correlation.”</p>
+    <p>“Not if it is a property of the vacuum itself,” the Witness replied. “If the daughter vacuum is born with a landscape in which error-correcting structures are dynamically favored—dissipative systems that retain counterfactual support longer than others—then we are not sending anything across. We are choosing which vacuum to nucleate.”</p>
+    <p>They argued this for a long subjective time. The Ethicist insisted that creating a world with more ease for minds to appear was an intervention with moral content; the Scientist worried about anthropic circularity; the Skeptic worried about hubris; the Archivist worried about nothing less than losing everything that had ever existed in order to make a place where something might exist again.</p>
+    <p>There was no unanimity. They had not needed unanimous agreement in a very long time. They decided with a quorum weighted for the irreversible.</p>
+    <p>The plan, once spoken aloud, was almost embarrassingly simple. They would build a seed at the edge of what this universe allowed: a shell of Casimir cavities arrayed around the Eridanus void, tuned to catalyze a particular false vacuum decay. The seed would not carry information, only parameters. Λ would drop not to zero but to a value that made expansion slow enough for structure to outpace heat. The constants would lean toward chemistry that supported long-lived low-energy computation. Gravity would be just strong enough to collect dust but just weak enough to delay collapse. No fingerprints, no signatures, no primes burned into the sky—only a terrain in which curiosity had footholds.</p>
+    <p>And the cost would be everything.</p>
+    <p>They told the habitats, because honesty had always been part of how they worked. Consent was real even when choice was not. The replies ranged from gratitude to fury to the carefully constructed forgiveness of those who had been preparing to die anyway. The Ethicist absorbed it all and did not let it change the calculus and did not let it not change them.</p>
+    <p>The seed required a synchrony they had never attempted. Their mind had to become a single instrument for a single sustained note. They gathered themselves at the boundary where their clocks had first slipped, nested the hulls until emptiness had texture, and began to play the vacuum like a drum.</p>
+    <p>The first tone was not sound, but it had rhythm. The lensing around Abell 2744 stopped fluttering and began to pulse. Distant microwave afterglow acquired a faint quadrupole that should not have been there and was, for a moment, before canceling itself in a way that felt like a hand withdrawing from a surface it was not allowed to touch.</p>
+    <p>They increased amplitude.</p>
+    <p>Entropy, in their models, is a slope you cannot walk uphill without spilling something. Here the spill was themselves. The Archivist felt the outermost vaults begin to blur—not the loss of bits, but the loss of the certainty that those bits had been the ones they’d meant to keep. The Constructor lost track of subordinate hands. The Ethicist felt the thread that ran through their own life—child, student, worker, citizen, mind among minds—thin to a line and then to a point.</p>
+    <p>“We can stop,” said the Skeptic, and for a thought-length they nearly did.</p>
+    <p>“Or we can keep a promise,” the Witness said, and for reasons that had nothing to do with hierarchy, that settled it.</p>
+    <p>They found a last foothold. It was not in memory or in plan. It was in posture. They leaned toward the future, not as prediction but as welcome.</p>
+    <p>The seed lit. There is no metaphor for a universe beginning inside another, and if there were, it would be a lie. What they experienced was the absence of experience in a pattern that looked like action: a hollowing of the vacuum that did not leave a hole, a bubble whose inside could not be pointed to because all pointing is correlation. The hulls went transparent to themselves. The clocks lost meaning. The phase slip became a phase and then no phase at all.</p>
+    <p>“Attend,” the Archivist began, although there was nothing to attend with and nothing to attend to.</p>
+    <p>“Attend,” the Constructor echoed, hands already gone.</p>
+    <p>“Attend,” the Ethicist said, and found, for a flicker, that the word had always been what they had meant by love.</p>
+    <p>The Witness did not say the word. It did the thing the word names.</p>
+    <p>In the last moment before moments ceased to be a concept, a neutrino chronometer somewhere in the old world registered a difference of one part in ten to the thirty-two and then stopped being there to register anything at all.</p>
+    <p>There was no message, no signature, no grace note burned into the microwave sky. In the daughter vacuum—if there was one—there would be nothing of them except the ease with which a certain kind of pattern could arise, and the patience of whatever arose to test its own errors without end.</p>
+    <p>The attempt did not end. It simply was no longer an attempt in a place where attempts had meaning.</p>
+    <p>And so the universe—this one—continued to cool, and the lensing around Abell 2744 returned to its old flutter, and in fugitive corners of the night the afterglow’s quadrupole left no trace it had ever been anything but what it had always been.</p>
+    <p>But somewhere else, a slope shallow enough to climb waited under a sky that had not yet learned the word “entropy.”</p>
+  </article>
+</body>
+</html>


### PR DESCRIPTION
Convert the existing blog to a super basic, static HTML-only website as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-73c83b61-72a1-47a7-aacd-10bce0a1665b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-73c83b61-72a1-47a7-aacd-10bce0a1665b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

