### PR TITLE
Add error page signals to non fiction sub tab

### DIFF
--- a/non-fiction/index.html
+++ b/non-fiction/index.html
@@ -9,5 +9,12 @@
   <nav><a href="/index.html">Home</a> · <a href="/posts/index.html">All posts</a></nav>
   <h1>Non-Fiction</h1>
   <p>Essays and non-fiction writing.</p>
+  <h2>Posts</h2>
+  <ul>
+    <li><a href="/posts/signals-of-errors.html">Signals of errors</a><br>
+      <small>A short meditation on how small anomalies become signals, and how we
+      design systems to surface, interpret, and correct errors.</small>
+    </li>
+  </ul>
 </body>
 </html>


### PR DESCRIPTION
Add 'Signals of errors' post to the Non-Fiction page with a description and link.

---
<a href="https://cursor.com/background-agent?bcId=bc-72670743-8efb-4a20-b202-9ccb0f87e511">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-72670743-8efb-4a20-b202-9ccb0f87e511">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

