### PR TITLE
Align sub page styles with entry page

### DIFF
--- a/code/index.html
+++ b/code/index.html
@@ -4,10 +4,24 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Code - Gabriel dernbach</title>
+<meta name="color-scheme" content="light dark">
+<link rel="stylesheet" href="/styles.css">
 </head>
 <body>
-  <nav><a href="/index.html">Home</a> · <a href="/posts/index.html">All posts</a></nav>
-  <h1>Code</h1>
-  <p>Notes, snippets, and essays about programming.</p>
+  <main class="container">
+    <header>
+      <h1>Code</h1>
+      <p>Notes, snippets, and essays about programming.</p>
+    </header>
+    <nav aria-label="Sections">
+      <ul class="links">
+        <li><a href="/index.html">Home</a></li>
+        <li><a href="/posts/index.html">All posts</a></li>
+      </ul>
+    </nav>
+    <footer>
+      <small>&copy; 2025</small>
+    </footer>
+  </main>
 </body>
 </html>

--- a/fiction/index.html
+++ b/fiction/index.html
@@ -4,17 +4,31 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Fiction - Gabriel dernbach</title>
+<meta name="color-scheme" content="light dark">
+<link rel="stylesheet" href="/styles.css">
 </head>
 <body>
-  <nav><a href="/index.html">Home</a> · <a href="/posts/index.html">All posts</a></nav>
-  <h1>Fiction</h1>
-  <p>Stories, experiments, and speculative worlds.</p>
-  <h2>Posts</h2>
-  <ul>
-    <li><a href="/fiction/signals-of-errors.html">Signals of errors</a><br>
-      <small>A short meditation on how small anomalies become signals, and how we
-      design systems to surface, interpret, and correct errors.</small>
-    </li>
-  </ul>
+  <main class="container">
+    <header>
+      <h1>Fiction</h1>
+      <p>Stories, experiments, and speculative worlds.</p>
+    </header>
+    <nav aria-label="Sections">
+      <ul class="links">
+        <li><a href="/index.html">Home</a></li>
+        <li><a href="/posts/index.html">All posts</a></li>
+      </ul>
+    </nav>
+    <h2>Posts</h2>
+    <ul>
+      <li><a href="/fiction/signals-of-errors.html">Signals of errors</a><br>
+        <small>A short meditation on how small anomalies become signals, and how we
+        design systems to surface, interpret, and correct errors.</small>
+      </li>
+    </ul>
+    <footer>
+      <small>&copy; 2025</small>
+    </footer>
+  </main>
 </body>
 </html>

--- a/fiction/signals-of-errors.html
+++ b/fiction/signals-of-errors.html
@@ -4,12 +4,23 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Signals of errors - Gabriel dernbach</title>
+<meta name="color-scheme" content="light dark">
+<link rel="stylesheet" href="/styles.css">
 </head>
 <body>
-  <nav><a href="/index.html">Home</a> · <a href="/fiction/index.html">Fiction</a> · <a href="/posts/index.html">All posts</a></nav>
-  <h1>Signals of errors</h1>
-  <p><small>Aug 26, 2025 · Fiction</small></p>
-  <article>
+  <main class="container">
+    <header>
+      <h1>Signals of errors</h1>
+      <p><small>Aug 26, 2025 · Fiction</small></p>
+    </header>
+    <nav aria-label="Sections">
+      <ul class="links">
+        <li><a href="/index.html">Home</a></li>
+        <li><a href="/fiction/index.html">Fiction</a></li>
+        <li><a href="/posts/index.html">All posts</a></li>
+      </ul>
+    </nav>
+    <article>
     <p>The first failure arrived as a phase slip in clocks that had never slipped.</p>
     <p>Across the lattice of neutrino chronometers anchored to intercluster voids, a microphase drift—one part in ten to the thirty-two—rolled eastward through the Eridanus supervoid like a cold front. The collective felt it the way a pianist feels the instrument go slightly out of tune: a sourness not in sound but in symmetry. Someone, somewhere, was losing their hold on time.</p>
     <p>“Noise?” asked the Constructor band.</p>
@@ -68,6 +79,10 @@
     <p>The attempt did not end. It simply was no longer an attempt in a place where attempts had meaning.</p>
     <p>And so the universe—this one—continued to cool, and the lensing around Abell 2744 returned to its old flutter, and in fugitive corners of the night the afterglow’s quadrupole left no trace it had ever been anything but what it had always been.</p>
     <p>But somewhere else, a slope shallow enough to climb waited under a sky that had not yet learned the word “entropy.”</p>
-  </article>
+    </article>
+    <footer>
+      <small>&copy; 2025</small>
+    </footer>
+  </main>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,74 +6,7 @@
 <title>Gabriel dernbach</title>
 <meta name="description" content="Ideas, code, and stories.">
 <meta name="color-scheme" content="light dark">
-<style>
-  :root {
-    --bg: #fafafa;
-    --fg: #111;
-    --muted: #666;
-    --border: #e6e6e6;
-  }
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --bg: #0b0b0c;
-      --fg: #e9e9ea;
-      --muted: #9a9aa0;
-      --border: #1e1e22;
-    }
-  }
-  html, body {
-    margin: 0;
-    padding: 0;
-    background: var(--bg);
-    color: var(--fg);
-  }
-  body {
-    font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
-    line-height: 1.6;
-  }
-  .container {
-    max-width: 720px;
-    margin: 6vh auto;
-    padding: 0 16px;
-  }
-  header h1 {
-    margin: 0;
-    font-size: 2rem;
-    letter-spacing: -0.01em;
-  }
-  header p {
-    margin: 8px 0 0;
-    color: var(--muted);
-  }
-  nav {
-    margin-top: 24px;
-    padding-top: 12px;
-    border-top: 1px solid var(--border);
-  }
-  ul.links {
-    list-style: none;
-    padding: 0;
-    margin: 12px 0 0;
-  }
-  ul.links li {
-    margin: 8px 0;
-  }
-  ul.links a {
-    display: inline-block;
-    padding: 6px 0;
-    color: inherit;
-    text-decoration: none;
-    border-bottom: 1px solid transparent;
-  }
-  ul.links a:hover {
-    border-bottom-color: var(--border);
-  }
-  footer {
-    margin-top: 32px;
-    color: var(--muted);
-    font-size: 0.9rem;
-  }
-</style>
+<link rel="stylesheet" href="/styles.css">
 </head>
 <body>
   <main class="container">

--- a/non-fiction/index.html
+++ b/non-fiction/index.html
@@ -4,13 +4,27 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Non-Fiction - Gabriel dernbach</title>
+<meta name="color-scheme" content="light dark">
+<link rel="stylesheet" href="/styles.css">
 </head>
 <body>
-  <nav><a href="/index.html">Home</a> · <a href="/posts/index.html">All posts</a></nav>
-  <h1>Non-Fiction</h1>
-  <p>Essays and non-fiction writing.</p>
-  <h2>Posts</h2>
-  <ul>
-  </ul>
+  <main class="container">
+    <header>
+      <h1>Non-Fiction</h1>
+      <p>Essays and non-fiction writing.</p>
+    </header>
+    <nav aria-label="Sections">
+      <ul class="links">
+        <li><a href="/index.html">Home</a></li>
+        <li><a href="/posts/index.html">All posts</a></li>
+      </ul>
+    </nav>
+    <h2>Posts</h2>
+    <ul>
+    </ul>
+    <footer>
+      <small>&copy; 2025</small>
+    </footer>
+  </main>
 </body>
 </html>

--- a/posts/index.html
+++ b/posts/index.html
@@ -4,12 +4,26 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>All posts - Gabriel dernbach</title>
+<meta name="color-scheme" content="light dark">
+<link rel="stylesheet" href="/styles.css">
 </head>
 <body>
-  <nav><a href="/index.html">Home</a></nav>
-  <h1>All posts</h1>
-  <ul>
-    <li><a href="/fiction/signals-of-errors.html">Signals of errors</a> <small>(Fiction)</small></li>
-  </ul>
+  <main class="container">
+    <header>
+      <h1>All posts</h1>
+      <p>Every published piece.</p>
+    </header>
+    <nav aria-label="Sections">
+      <ul class="links">
+        <li><a href="/index.html">Home</a></li>
+      </ul>
+    </nav>
+    <ul>
+      <li><a href="/fiction/signals-of-errors.html">Signals of errors</a> <small>(Fiction)</small></li>
+    </ul>
+    <footer>
+      <small>&copy; 2025</small>
+    </footer>
+  </main>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,74 @@
+:root {
+  --bg: #fafafa;
+  --fg: #111;
+  --muted: #666;
+  --border: #e6e6e6;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0b0b0c;
+    --fg: #e9e9ea;
+    --muted: #9a9aa0;
+    --border: #1e1e22;
+  }
+}
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+}
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+  line-height: 1.6;
+}
+.container {
+  max-width: 720px;
+  margin: 6vh auto;
+  padding: 0 16px;
+}
+header h1 {
+  margin: 0;
+  font-size: 2rem;
+  letter-spacing: -0.01em;
+}
+header p {
+  margin: 8px 0 0;
+  color: var(--muted);
+}
+nav {
+  margin-top: 24px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+ul.links {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+}
+ul.links li {
+  margin: 8px 0;
+}
+ul.links a {
+  display: inline-block;
+  padding: 6px 0;
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+ul.links a:hover {
+  border-bottom-color: var(--border);
+}
+footer {
+  margin-top: 32px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+/* Generic elements */
+article {
+  margin-top: 16px;
+}
+small {
+  color: var(--muted);
+}


### PR DESCRIPTION
Extract shared styles to `styles.css` and apply consistent layout to all pages to match the entry page's style.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ccfddb1-dabc-4e45-aec1-9779c6beea70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9ccfddb1-dabc-4e45-aec1-9779c6beea70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

