### PR TITLE
Fix fiction landing page and posts

### DIFF
--- a/fiction/index.html
+++ b/fiction/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Fiction - Gabriel dernbach</title>
+<meta name="color-scheme" content="light">
+<meta name="theme-color" content="#fdf6e3">
+<link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <main class="container">
+    <header>
+      <h1>Fiction</h1>
+      <p>Stories and speculative writing.</p>
+    </header>
+    <nav aria-label="Sections">
+      <ul class="links">
+        <li><a href="/index.html">Home</a></li>
+      </ul>
+    </nav>
+    <h2>Posts</h2>
+    <ul>
+      <li>
+        <a href="/fiction/signals-of-errors.html">Signals of errors</a>
+        <small>— Aug 26, 2025</small>
+      </li>
+    </ul>
+    <footer>
+      <small>&copy; 2025</small>
+    </footer>
+  </main>
+</body>
+</html>
+


### PR DESCRIPTION
Create the `fiction/index.html` landing page to fix the broken link and display its posts.

---
<a href="https://cursor.com/background-agent?bcId=bc-9122f420-9413-4e13-8d39-467a4388ef56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9122f420-9413-4e13-8d39-467a4388ef56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

